### PR TITLE
Reimplement Cache-Control response header for bite.js script

### DIFF
--- a/conversion/now.json
+++ b/conversion/now.json
@@ -5,6 +5,17 @@
       "BA_HOST": "@ba-host"
     }
   },
+  "headers": [
+    {
+      "source": "/v1/bite.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=31536000, immutable"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/v1/bite.js",


### PR DESCRIPTION
As discussed here https://github.com/barnebys/analytics/pull/9#discussion_r357907151

This does not seem to alter any behaviour, might be that `now dev` doesn't support it but I'm not too sure. 